### PR TITLE
Fix build errors on Linux

### DIFF
--- a/Aurora/CMakeLists.txt
+++ b/Aurora/CMakeLists.txt
@@ -89,7 +89,7 @@ if(BUILD_EXAMPLES)
 			endif()
 		else()
 			set_target_properties( glfw PROPERTIES IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/External/glfw/libX11/libglfw.a )
-			set(GLFW_LIBRARIES glfw X11)
+			set(GLFW_LIBRARIES glfw X11 pthread)
 		endif()
 	endif()
 

--- a/Aurora/Systems/LogSystem/ThreadsafeLogSystem/ThreadsafeLogSystem_PlatformWindows.cpp
+++ b/Aurora/Systems/LogSystem/ThreadsafeLogSystem/ThreadsafeLogSystem_PlatformWindows.cpp
@@ -29,7 +29,7 @@ typedef pthread_mutex_t CRITICAL_SECTION;
 
 void InitializeCriticalSection( CRITICAL_SECTION* pCrit )
 {
-    *pCrit = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_init(pCrit, NULL);
 }
 
 void DeleteCriticalSection( CRITICAL_SECTION* pCrit )


### PR DESCRIPTION
As reported here: https://groups.google.com/d/topic/runtimecompiledcplusplus/0SMPjmI1524/discussion

The CMake build is missing the link to pthread on Linux. Looking at the documentation here: http://www.glfw.org/release-2.7.7.html#22_x11_on_unixlike_systems it says:

> _GLFW_HAS_PTHREAD 
> Use the POSIX Threads API for threading. This is the only supported API for the X11 port. Without it, threading will be disabled.

The static library provided Aurora/External/glfw/libX11/libglfw.a has been built with pthread support.

On Linux, `PTHREAD_MUTEX_INITIALIZER` can only be used at the ~definition of a variable (such as init list or whatever accept braces initialization).
