### PR TITLE
Fix compile error with VS 2013

### DIFF
--- a/Aurora/Examples/SimpleTest/SplashScreen.cpp
+++ b/Aurora/Examples/SimpleTest/SplashScreen.cpp
@@ -31,6 +31,10 @@
 #include <assert.h>
 #include <stdio.h>
 
+#if (_MSC_VER == 1800)
+#include <algorithm>
+#endif
+
 class SplashScreen: public ISplashScreen, public IFileChangeListener, public IGUIEventListener
 {
 public:


### PR DESCRIPTION
According to this http://msdn.microsoft.com/en-us/library/vstudio/bb531344(v=vs.120).aspx, <algorithm> must be included to use std::min() and std::max()
