### PR TITLE
make TActual::m_constructor public

### DIFF
--- a/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
@@ -360,10 +360,11 @@ public:
 	{
 		return GetTypeNameStatic();
 	}
+	static TObjectConstructorConcrete<TActual> m_Constructor;
 private:
 	void SetPerTypeId( PerTypeObjectId id ) { m_Id = id; }
 	PerTypeObjectId m_Id;
-	static TObjectConstructorConcrete<TActual> m_Constructor;
+	
 };
 #ifndef RCCPPOFF
 	#define REGISTERBASE( T, bIsSingleton, bIsAutoConstructSingleton )	\


### PR DESCRIPTION
When trying to compile SimpleTest with VS 2013, the REGISTERBASE macro, which is used when REGISTERCLASS is used, tries to access m_Constructor, which is private. I don't know why it's private but there is probably a reason for it. Either way, "dirty fix" is to make it public.