### PR TITLE
Changed to have IRuntimeObjectSystem derive from ITestBuildNotifier 

### DIFF
--- a/Aurora/RuntimeObjectSystem/IRuntimeObjectSystem.h
+++ b/Aurora/RuntimeObjectSystem/IRuntimeObjectSystem.h
@@ -62,7 +62,7 @@ namespace FileSystemUtils
     class Path;
 }
 
-struct IRuntimeObjectSystem
+struct IRuntimeObjectSystem : public ITestBuildNotifier
 {
 	// Initialise RuntimeObjectSystem. pLogger and pSystemTable should be deleted by creator. 
 	// Both pLogger and pSystemTable can be 0

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.h
@@ -41,7 +41,7 @@
 struct ICompilerLogger;
 struct IObjectFactorySystem;
 
-class RuntimeObjectSystem : public IRuntimeObjectSystem, public IFileChangeListener, public ITestBuildNotifier
+class RuntimeObjectSystem : public IRuntimeObjectSystem, IFileChangeListener
 {
 public:
 	RuntimeObjectSystem();


### PR DESCRIPTION
This makes it easier to use, as devs can call the IRuntimeObjectSystem callbacks they don't want to handle themselves.
