### PR TITLE
CMake added -DCMAKE_INSTALL_PREFIX option

### DIFF
--- a/Aurora/CMakeLists.txt
+++ b/Aurora/CMakeLists.txt
@@ -33,6 +33,18 @@ if(UNIX)
 	target_link_libraries(RuntimeObjectSystem dl)
 endif()
 
+#
+# Make Install
+#
+install(DIRECTORY Common/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Common
+	FILES_MATCHING PATTERN "*.inl")
+install(DIRECTORY RuntimeObjectSystem/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/RuntimeObjectSystem
+	FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY RuntimeCompiler/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/RuntimeCompiler
+	FILES_MATCHING PATTERN "*.h")
+install(TARGETS RuntimeObjectSystem RuntimeCompiler 
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
+
 if(BUILD_EXAMPLES)
 
 	#


### PR DESCRIPTION
Placing the built libraries under a separate location helps to keep things clear, especially while working with custom toolchains. At the moment  it is hard to find all required headers to the core RCCPP library. The point is to place the core (RuntimeObjectSystem RuntimeCompiler libraries+headers) in separate place and leave all examples and external libraries (shipped with the source) where they are.
