### PR TITLE
Moved CompilerOptions struct to Compiler.h to remove requirement for Fil...

### DIFF
--- a/Aurora/RuntimeCompiler/CompileOptions.h
+++ b/Aurora/RuntimeCompiler/CompileOptions.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include "FileSystemUtils.h"
-
 enum RCppOptimizationLevel
 {
 	RCCPPOPTIMIZATIONLEVEL_DEFAULT = 0,		// RCCPPOPTIMIZATIONLEVEL_DEBUG in DEBUG, RCCPPOPTIMIZATIONLEVEL_PERF in release. This is the default state.
@@ -49,14 +47,3 @@ inline RCppOptimizationLevel GetActualOptimizationLevel( RCppOptimizationLevel o
 	}
 	return optimizationLevel_;
 }
-
-struct CompilerOptions
-{
-	std::vector<FileSystemUtils::Path>	includeDirList;
-	std::vector<FileSystemUtils::Path>	libraryDirList;
-	std::string							compileOptions;
-	std::string							linkOptions;
-  	RCppOptimizationLevel				optimizationLevel;
-	FileSystemUtils::Path				intermediatePath;
-	FileSystemUtils::Path				compilerLocation;
-};

--- a/Aurora/RuntimeCompiler/Compiler.h
+++ b/Aurora/RuntimeCompiler/Compiler.h
@@ -26,6 +26,17 @@
 class PlatformCompilerImplData;
 struct ICompilerLogger;
 
+struct CompilerOptions
+{
+	std::vector<FileSystemUtils::Path>	includeDirList;
+	std::vector<FileSystemUtils::Path>	libraryDirList;
+	std::string							compileOptions;
+	std::string							linkOptions;
+  	RCppOptimizationLevel				optimizationLevel;
+	FileSystemUtils::Path				intermediatePath;
+	FileSystemUtils::Path				compilerLocation;
+};
+
 class Compiler
 {
 public:


### PR DESCRIPTION
...eSystemUtils.h, vector and string from external interface.
