### PR TITLE
Support for VS2017 Update 3

### DIFF
--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -463,7 +463,8 @@ void GetPathsOfVisualStudioInstalls( std::vector<VSVersionInfo>* pVersions )
 		startVersion = 5;
 		break;
 	case 1910:	//VS 2017
-		startVersion = 6;
+    case 1911:	//VS 2017
+        startVersion = 6;
 		break;
 	default:
 		assert( false ); //unsupported compiler, find MSCVERSION to add case

--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -463,8 +463,8 @@ void GetPathsOfVisualStudioInstalls( std::vector<VSVersionInfo>* pVersions )
 		startVersion = 5;
 		break;
 	case 1910:	//VS 2017
-    case 1911:	//VS 2017
-        startVersion = 6;
+	case 1911:	//VS 2017
+		startVersion = 6;
 		break;
 	default:
 		assert( false ); //unsupported compiler, find MSCVERSION to add case


### PR DESCRIPTION
Microsoft is updating _MSC_VER more frequently now, even for updates.
See the release notes for 15.3 at:
https://blogs.msdn.microsoft.com/chuckw/2017/08/14/visual-studio-2017-15-3-update/