### PR TITLE
New tracking template RuntimeTracking

### DIFF
--- a/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
@@ -212,6 +212,7 @@ void Compiler::RunCompile( const std::vector<FileSystemUtils::Path>&	filesToComp
 		compileString += "-Os ";
 		break;
 	case RCCPPOPTIMIZATIONLEVEL_NOT_SET:;
+	case RCCPPOPTIMIZATIONLEVEL_SIZE:;
 	}
     
 	// Check for intermediate directory, create it if required

--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -319,6 +319,7 @@ void Compiler::RunCompile(	const std::vector<FileSystemUtils::Path>&	filesToComp
 #endif
 		break;
 	case RCCPPOPTIMIZATIONLEVEL_NOT_SET:;
+	case RCCPPOPTIMIZATIONLEVEL_SIZE:;
 	}
 
 	if( NULL == m_pImplData->m_CmdProcessInfo.hProcess )

--- a/Aurora/RuntimeCompiler/FileSystemUtils.h
+++ b/Aurora/RuntimeCompiler/FileSystemUtils.h
@@ -41,6 +41,7 @@
     #include <string.h>
     #include <unistd.h>
     #include <dirent.h>
+    #include <assert.h>
 	#define FILESYSTEMUTILS_SEPERATORS "/"
 #endif
 

--- a/Aurora/RuntimeObjectSystem/ObjectInterface.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterface.h
@@ -64,7 +64,7 @@ struct ObjectId
 	}
 };
 
-struct SourceDependencyInfo;
+struct RuntimeTackingInfo;
 
 struct IObjectConstructor
 {
@@ -73,12 +73,8 @@ struct IObjectConstructor
 	virtual const char* GetName() = 0;
 	virtual const char* GetFileName() = 0;
 	virtual const char* GetCompiledPath() = 0;
-	virtual size_t GetMaxNumIncludeFiles() const = 0;
-	virtual const char* GetIncludeFile( size_t Num_ ) const = 0;
-	virtual size_t GetMaxNumLinkLibraries() const = 0;
-	virtual const char* GetLinkLibrary( size_t Num_ ) const = 0;
-	virtual size_t GetMaxNumSourceDependencies() const = 0;
-	virtual SourceDependencyInfo GetSourceDependency( size_t Num_ ) const = 0;
+	virtual size_t GetMaxNumTrackingInfo() const = 0;
+	virtual RuntimeTackingInfo GetTrackingInfo( size_t Num_ ) const = 0;
     virtual void SetProjectId( unsigned short projectId_ ) = 0;
     virtual unsigned short GetProjectId() const = 0;
 

--- a/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
@@ -90,9 +90,7 @@ public:
 	TObjectConstructorConcrete(
 #ifndef RCCPPOFF
 		const char* Filename,
-		IRuntimeIncludeFileList*        pIncludeFileList_,
-        IRuntimeSourceDependencyList*   pSourceDependencyList_,
-        IRuntimeLinkLibraryList*        pLinkLibraryList,
+        IRuntimeTracking*				pRuntimeTrackingList_,
 #endif
         bool                            bIsSingleton,
         bool                            bIsAutoConstructSingleton)
@@ -102,9 +100,7 @@ public:
         , m_Project(0)
 #ifndef RCCPPOFF
 		, m_FileName(                   Filename )
-		, m_pIncludeFileList(pIncludeFileList_)
-		, m_pSourceDependencyList(pSourceDependencyList_)
-		, m_pLinkLibraryList(pLinkLibraryList)
+		, m_pRuntimeTrackingList(pRuntimeTrackingList_)
 #endif
 	{
 #ifndef RCCPPOFF
@@ -191,67 +187,23 @@ public:
 #endif
    }
 
-	virtual const char* GetIncludeFile( size_t Num_ ) const
+	virtual RuntimeTackingInfo GetTrackingInfo( size_t Num_ ) const
 	{
 #ifndef RCCPPOFF
-		if( m_pIncludeFileList )
+		if( m_pRuntimeTrackingList )
 		{
-			return m_pIncludeFileList->GetIncludeFile( Num_ );
+			return m_pRuntimeTrackingList->GetTrackingInfo( Num_ );
 		}
 #endif
-		return 0;
+		return RuntimeTackingInfo::GetNULL();
 	}
 
-	virtual size_t GetMaxNumIncludeFiles() const
+	virtual size_t GetMaxNumTrackingInfo() const
 	{
 #ifndef RCCPPOFF
-		if( m_pIncludeFileList )
+		if( m_pRuntimeTrackingList )
 		{
-			return m_pIncludeFileList->MaxNum;
-		}
-#endif
-		return 0;
-	}
-
-	virtual const char* GetLinkLibrary( size_t Num_ ) const
-	{
-#ifndef RCCPPOFF
-		if( m_pLinkLibraryList )
-		{
-			return m_pLinkLibraryList->GetLinkLibrary( Num_ );
-		}
-#endif
-		return 0;
-	}
-
-	virtual size_t GetMaxNumLinkLibraries() const
-	{
-#ifndef RCCPPOFF
-		if( m_pLinkLibraryList )
-		{
-			return m_pLinkLibraryList->MaxNum;
-		}
-#endif
-		return 0;
-	}
-
-	virtual SourceDependencyInfo GetSourceDependency( size_t Num_ ) const
-	{
-#ifndef RCCPPOFF
-		if( m_pSourceDependencyList )
-		{
-			return m_pSourceDependencyList->GetSourceDependency( Num_ );
-		}
-#endif
-		return SourceDependencyInfo::GetNULL();
-	}
-
-	virtual size_t GetMaxNumSourceDependencies() const
-	{
-#ifndef RCCPPOFF
-		if( m_pSourceDependencyList )
-		{
-			return m_pSourceDependencyList->MaxNum;
+			return m_pRuntimeTrackingList->MaxNum;
 		}
 #endif
 		return 0;
@@ -322,9 +274,7 @@ private:
     unsigned short                  m_Project;
 #ifndef RCCPPOFF
 	std::string                     m_FileName;
-	IRuntimeIncludeFileList*        m_pIncludeFileList;
-	IRuntimeSourceDependencyList*   m_pSourceDependencyList;
-	IRuntimeLinkLibraryList*        m_pLinkLibraryList;
+	IRuntimeTracking*				m_pRuntimeTrackingList;
 #endif
 };
 
@@ -373,10 +323,8 @@ private:
 };
 #ifndef RCCPPOFF
 	#define REGISTERBASE( T, bIsSingleton, bIsAutoConstructSingleton )	\
-		static RuntimeIncludeFiles< __COUNTER__ >       g_includeFileList_##T; \
-		static RuntimeSourceDependency< __COUNTER__ >   g_sourceDependencyList_##T; \
-		static RuntimeLinkLibrary< __COUNTER__ >        g_linkLibraryList_##T; \
-	template<> TObjectConstructorConcrete< TActual< T > > TActual< T >::m_Constructor( __FILE__, &g_includeFileList_##T, &g_sourceDependencyList_##T, &g_linkLibraryList_##T, bIsSingleton, bIsAutoConstructSingleton );\
+	static RuntimeTracking< __COUNTER__ >	   g_runtimeTrackingList_##T; \
+	template<> TObjectConstructorConcrete< TActual< T > > TActual< T >::m_Constructor( __FILE__, &g_runtimeTrackingList_##T, bIsSingleton, bIsAutoConstructSingleton );\
 	template<> const char* TActual< T >::GetTypeNameStatic() { return #T; } \
 	template class TActual< T >;
 #else

--- a/Aurora/RuntimeObjectSystem/RuntimeLinkLibrary.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeLinkLibrary.h
@@ -22,87 +22,34 @@
 
 
 #ifndef RCCPPOFF
-//NOTE: the file macro will only emit the full path if /FC option is used in visual studio or /ZI (Which forces /FC)
-//Following creates a list of files which are runtime modifiable, to be used in headers
-//requires use of __COUNTER__ predefined macro, which is in gcc 4.3+, clang/llvm and MSVC
 
-struct IRuntimeLinkLibraryList
-{
-	IRuntimeLinkLibraryList( size_t max ) : MaxNum( max )
-	{
-	}
-
-	// GetIncludeFile may return 0, so you should iterate through to GetMaxNum() ignoring 0 returns
-	virtual const char* GetLinkLibrary( size_t Num_ ) const
-	{
-		return 0;
-	}
-	size_t MaxNum; // initialized in constructor below
-};
-
-
-namespace
-{
-
-template< size_t COUNT > struct RuntimeLinkLibrary : public RuntimeLinkLibrary<COUNT-1>
-{
-	RuntimeLinkLibrary( size_t max ) : RuntimeLinkLibrary<COUNT-1>( max )
-	{
-	}
-	RuntimeLinkLibrary() : RuntimeLinkLibrary<COUNT-1>( COUNT )
-	{
-	}
-
-	virtual const char* GetLinkLibrary( size_t Num_ ) const
-	{
-		if( Num_ < COUNT )
-		{
-			return this->RuntimeLinkLibrary< COUNT-1 >::GetLinkLibrary( Num_ );
-		}
-		else return 0;
-	}
-};
-
-template<> struct RuntimeLinkLibrary<0> : public IRuntimeLinkLibraryList
-{
-	RuntimeLinkLibrary( size_t max ) : IRuntimeLinkLibraryList( max )
-	{
-	}
-	RuntimeLinkLibrary() : IRuntimeLinkLibraryList( 0 )
-	{
-	}
-
-	virtual const char* GetLinkLibrary( size_t Num_ ) const
-	{
-		return 0;
-	} 
-};
-
-
+#include "RuntimeTracking.h"
 
 #define RUNTIME_COMPILER_LINKLIBRARY_BASE( LIBRARY, N ) \
-	template<> struct RuntimeLinkLibrary< N + 1 >  : public RuntimeLinkLibrary< N >\
+RCCPP_OPTMIZE_OFF \
+template<> struct RuntimeTracking< N + 1 >  : RuntimeTracking< N >\
+{ \
+	RuntimeTracking( size_t max ) : RuntimeTracking<N>( max ) {} \
+	RuntimeTracking< N + 1 >() : RuntimeTracking<N>( N + 1 ) {} \
+	virtual RuntimeTackingInfo GetTrackingInfo( size_t Num_ ) const \
 	{ \
-		RuntimeLinkLibrary( size_t max ) : RuntimeLinkLibrary<N>( max ) {} \
-		RuntimeLinkLibrary< N + 1 >() : RuntimeLinkLibrary<N>( N + 1 ) {} \
-		virtual const char* GetLinkLibrary( size_t Num_ ) const \
+		if( Num_ <= N ) \
 		{ \
-			if( Num_ <= N ) \
+			if( Num_ == N ) \
 			{ \
-				if( Num_ == N ) \
-				{ \
-					return LIBRARY; \
-				} \
-				else return this->RuntimeLinkLibrary< N >::GetLinkLibrary( Num_ ); \
+				RuntimeTackingInfo info = RuntimeTackingInfo::GetNULL(); \
+				info.linkLibrary = LIBRARY; \
+				return info; \
 			} \
-			else return 0; \
+			else return this->RuntimeTracking< N >::GetTrackingInfo( Num_ ); \
 		} \
-	}; \
+		else return RuntimeTackingInfo::GetNULL(); \
+	} \
+}; \
+RCCPP_OPTMIZE_ON
 
+#define RUNTIME_COMPILER_LINKLIBRARY( LIBRARY ) namespace { RUNTIME_COMPILER_LINKLIBRARY_BASE( LIBRARY, __COUNTER__ - COUNTER_OFFSET ) }
 
-#define RUNTIME_COMPILER_LINKLIBRARY( LIBRARY ) namespace { RUNTIME_COMPILER_LINKLIBRARY_BASE( LIBRARY, __COUNTER__ ) }
-
-}
 #else
 #define RUNTIME_COMPILER_LINKLIBRARY( LIBRARY )
 #endif //RCCPPOFF

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
@@ -496,11 +496,14 @@ void RuntimeObjectSystem::SetupRuntimeFileTracking(const IAUDynArray<IObjectCons
 
         //we need the compile path for some platforms where the __FILE__ path is relative to the compile path
 		FileSystemUtils::Path compileDir = constructors_[i]->GetCompiledPath();
-
-		//add include file mappings
-		for (size_t includeNum = 0; includeNum <= constructors_[i]->GetMaxNumIncludeFiles(); ++includeNum)
+            
+ 		//add tracking information (include file, link libraries, source dependencies)
+		for (size_t trackInfoNum = 0; trackInfoNum <= constructors_[i]->GetMaxNumTrackingInfo(); ++trackInfoNum)
 		{
-			const char* pIncludeFile = constructors_[i]->GetIncludeFile(includeNum);
+			RuntimeTackingInfo rttInfo = constructors_[i]->GetTrackingInfo(trackInfoNum);
+
+			//add include file mappings
+			const char* pIncludeFile = rttInfo.includeFile;
 			if( pIncludeFile )
 			{
                 FileSystemUtils::Path pathInc = compileDir / pIncludeFile;
@@ -511,13 +514,9 @@ void RuntimeObjectSystem::SetupRuntimeFileTracking(const IAUDynArray<IObjectCons
                 AddToRuntimeFileList( pathInc.c_str(), projectId );
                 project.m_RuntimeIncludeMap.insert( includePathPair );
 			}
-		}
-            
 
- 		//add link library file mappings
-		for (size_t linklibraryNum = 0; linklibraryNum <= constructors_[i]->GetMaxNumLinkLibraries(); ++linklibraryNum)
-		{
-			const char* pLinkLibrary = constructors_[i]->GetLinkLibrary(linklibraryNum);
+			//add link library file mappings
+			const char* pLinkLibrary = rttInfo.linkLibrary;
 			if( pLinkLibrary )
 			{
                 // We do not use FindFiles for Linked Libraries as these are searched for on
@@ -527,15 +526,12 @@ void RuntimeObjectSystem::SetupRuntimeFileTracking(const IAUDynArray<IObjectCons
 				linklibraryPathPair.second = pLinkLibrary;
                 project.m_RuntimeLinkLibraryMap.insert( linklibraryPathPair );
 			}
-		}
 
-        //add source dependency file mappings
-		for (size_t num = 0; num <= constructors_[i]->GetMaxNumSourceDependencies(); ++num)
-		{
-			SourceDependencyInfo sourceDependency = constructors_[i]->GetSourceDependency(num);
-			FileSystemUtils::Path pathInc[2];	// array of potential include files for later checks
+			//add source dependency file mappings
+			SourceDependencyInfo sourceDependency = rttInfo.sourceDependencyInfo;
 			if( sourceDependency.filename )
 			{
+				FileSystemUtils::Path pathInc[2];	// array of potential include files for later checks
 				FileSystemUtils::Path pathSrc;
 				if( sourceDependency.relativeToPath )
 				{

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.vcxproj
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.vcxproj
@@ -31,6 +31,7 @@
     <ClInclude Include="RuntimeInclude.h" />
     <ClInclude Include="RuntimeLinkLibrary.h" />
     <ClInclude Include="RuntimeObjectSystem.h" />
+    <ClInclude Include="RuntimeTracking.h" />
     <ClInclude Include="SimpleSerializer\SimpleSerializer.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.vcxproj.filters
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.vcxproj.filters
@@ -30,6 +30,7 @@
     <ClInclude Include="RuntimeLinkLibrary.h" />
     <ClInclude Include="RuntimeProtector.h" />
     <ClInclude Include="RuntimeSourceDependency.h" />
+    <ClInclude Include="RuntimeTracking.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="SimpleSerializer">

--- a/Aurora/RuntimeObjectSystem/RuntimeTracking.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeTracking.h
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2017 Doug Binks
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+#pragma once
+
+// the templates used for tracking need not be optimized
+// so we create macros to handle this
+#ifdef _WIN32
+	#define RCCPP_OPTMIZE_OFF __pragma( optimize( "", off ) )
+	#define RCCPP_OPTMIZE_ON  __pragma( optimize( "", on ) )
+#else
+	#define RCCPP_OPTMIZE_OFF
+	#define RCCPP_OPTMIZE_ON
+#endif
+
+
+// Source Dependencies are constructed from a macro template from sources which may include
+// the __FILE__ macro, so to reduce inter-dependencies we return three values which are combined
+// by the higher level code. The full source dependency filename is then pseudo-code:
+// RemoveAnyFileName( relativeToPath ) + ReplaceExtension( filename, extension  )
+struct SourceDependencyInfo
+{
+	const char* filename;			// If NULL then no SourceDependencyInfo
+	const char* extension;			// If NULL then use extension in filename
+	const char* relativeToPath;		// If NULL filename is either full or relative to known path
+};
+
+struct RuntimeTackingInfo
+{
+    static RuntimeTackingInfo GetNULL() { RuntimeTackingInfo ret = {0}; return ret; }
+	SourceDependencyInfo sourceDependencyInfo;
+	const char*          linkLibrary;
+	const char*          includeFile;
+};
+
+
+#ifndef RCCPPOFF
+
+#include <stddef.h>
+
+RCCPP_OPTMIZE_OFF
+
+struct IRuntimeTracking
+{
+	IRuntimeTracking( size_t max ) : MaxNum( max )
+	{
+	}
+
+	// GetIncludeFile may return 0, so you should iterate through to GetMaxNum() ignoring 0 returns
+	virtual RuntimeTackingInfo GetTrackingInfo( size_t Num_ ) const
+	{
+		return RuntimeTackingInfo::GetNULL();
+	}
+
+	size_t MaxNum; // initialized in constructor below
+};
+
+
+namespace
+{
+const size_t COUNTER_OFFSET = __COUNTER__;
+
+template< size_t COUNT > struct RuntimeTracking : RuntimeTracking<COUNT-1>
+{
+	RuntimeTracking( size_t max ) : RuntimeTracking<COUNT-1>( max )
+	{
+	}
+	RuntimeTracking() : RuntimeTracking<COUNT-1>( COUNT )
+	{
+	}
+};
+
+template<> struct RuntimeTracking<0> : IRuntimeTracking
+{
+	RuntimeTracking( size_t max ) : IRuntimeTracking( max )
+	{
+	}
+	RuntimeTracking() : IRuntimeTracking( 0 )
+	{
+	}
+};
+
+RCCPP_OPTMIZE_ON
+
+}
+
+#endif


### PR DESCRIPTION
The template RuntimeTracking replaces RuntimeIncludeFileList, RuntimeLinkLibraryList and RuntimeSourceDependencyList, using duck type RuntimeTrackignInfo to hold all three sets of information. This helps optimize compile times, and should help initialize times slightly.

There should be no breaking API changes unless you have use the internal APIs.