### PR TITLE
Correct warnings

### DIFF
--- a/Aurora/RuntimeCompiler/AUArray.h
+++ b/Aurora/RuntimeCompiler/AUArray.h
@@ -73,7 +73,7 @@ public:
 		this->m_vec.resize(size);
 	}
 
-	~AUDynArray<T>()
+	virtual ~AUDynArray<T>()
 	{
 		// Ensure this code is created, despite the templates
 		Resize(0);

--- a/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
@@ -38,7 +38,7 @@
 #include "ICompilerLogger.h"
 
 using namespace std;
-const char	c_CompletionToken[] = "_COMPLETION_TOKEN_" ;
+//const char	c_CompletionToken[] = "_COMPLETION_TOKEN_" ;
 
 class PlatformCompilerImplData
 {

--- a/Aurora/RuntimeCompiler/FileChangeNotifier.cpp
+++ b/Aurora/RuntimeCompiler/FileChangeNotifier.cpp
@@ -111,6 +111,8 @@ void FileChangeNotifier::RemoveListener( IFileChangeListener *pListener )
 void FileChangeNotifier::handleFileAction( FW::WatchID watchid, const FW::String& dir, const FW::String& filename,
     FW::Action action )
 {
+	(void)action;
+	(void)watchid;
 	if (m_bActive)
 	{
         FileSystemUtils::Path filePath(filename);

--- a/Aurora/RuntimeCompiler/FileChangeNotifier.cpp
+++ b/Aurora/RuntimeCompiler/FileChangeNotifier.cpp
@@ -26,13 +26,13 @@ using namespace std;
 
 
 FileChangeNotifier::FileChangeNotifier()
-	: m_bActive(true)
+	: m_pFileWatcher( new FW::FileWatcher() ) // Create the file watch object
+	,	m_bActive(true)
 	, m_bRecompilePending(false)
 	, m_fMinTimeBetweenNotifications(DEFAULT_MIN_TIME_BETWEEN_RECOMPILES)
 	, m_fChangeNotifyDelay(DEFAULT_NOTIFY_DELAY)
 	, m_fTimeUntilNextAllowedRecompile(0.0f)
 	, m_fFileChangeSpamTimeRemaining(0.0f)
-    , m_pFileWatcher( new FW::FileWatcher() ) // Create the file watch object
 {
 	m_LastFileChanged = "";
 }

--- a/Aurora/RuntimeCompiler/FileSystemUtils.h
+++ b/Aurora/RuntimeCompiler/FileSystemUtils.h
@@ -155,7 +155,7 @@ namespace FileSystemUtils
 		_wfopen_s( &fp, wideStr.c_str(), wideMode.c_str() );
 		return fp;
 #else
-		return fopen( path_.m_string.c_str(), mode_ );
+		return ::fopen( path_.m_string.c_str(), mode_ );
 #endif
 	}
 

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcher.cpp
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcher.cpp
@@ -80,4 +80,4 @@ namespace FW
 		mImpl->update();
 	}
 
-};//namespace FW
+}//namespace FW

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcher.h
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcher.h
@@ -61,7 +61,7 @@ namespace FW
 			/// Sent when a file is modified
 			Modified = 4
 		};
-	};
+	}
 	typedef Actions::Action Action;
 
 	/// Listens to files and directories and dispatches events
@@ -118,6 +118,6 @@ namespace FW
 
 	};//class FileWatchListener
 
-};//namespace FW
+}//namespace FW
 
 #endif//_FW_FILEWATCHER_H_

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherImpl.h
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherImpl.h
@@ -73,6 +73,6 @@ namespace FW
 		virtual void handleAction(WatchStruct* watch, const String& filename, unsigned long action) = 0;
 
 	};//end FileWatcherImpl
-};//namespace FW
+}//namespace FW
 
 #endif//_FW_FILEWATCHERIMPL_H_

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherLinux.cpp
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherLinux.cpp
@@ -172,6 +172,6 @@ namespace FW
 		}
 	}
 
-};//namespace FW
+}//namespace FW
 
 #endif//FILEWATCHER_PLATFORM_LINUX

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherLinux.cpp
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherLinux.cpp
@@ -73,6 +73,7 @@ namespace FW
 	//--------
 	WatchID FileWatcherLinux::addWatch(const String& directory, FileWatchListener* watcher, bool recursive)
 	{
+        (void)recursive;
 		const char* pDir = directory.c_str();
 		int wd = inotify_add_watch (mFD, pDir,
 			IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_MOVED_FROM | IN_DELETE | IN_MODIFY | IN_ATTRIB );

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherLinux.h
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherLinux.h
@@ -84,7 +84,7 @@ namespace FW
 
 	};//end FileWatcherLinux
 
-};//namespace FW
+}//namespace FW
 
 #endif//FILEWATCHER_PLATFORM_LINUX
 

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherOSX.cpp
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherOSX.cpp
@@ -174,8 +174,8 @@ namespace FW
                         size_t currFile = fileIndex+1;
                         while( currFile < mFileListCount )
                         {
-                            FileInfo& entry = mFileList[currFile];
-                            int res = strcmp(entry.mFilename, fname.c_str());
+                            FileInfo& entry2 = mFileList[currFile];
+                            int res = strcmp(entry2.mFilename, fname.c_str());
                             if(res == 0)
                             {
                                 //have found the file in our list
@@ -190,8 +190,8 @@ namespace FW
                            //have some deletions.
                            while( fileIndex < currFile )
                            {
-                               FileInfo& entry = mFileList[currFile];
-                               handleAction(entry.mFilename, Actions::Delete);
+                               FileInfo& entry2 = mFileList[currFile];
+                               handleAction(entry2.mFilename, Actions::Delete);
                                ++fileIndex;
                            }
                             ++fileIndex;

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherOSX.cpp
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherOSX.cpp
@@ -273,7 +273,7 @@ namespace FW
 		void removeAll()
 		{
 			// go through list removing each file but not the directory
-			for(int i = 0; i < mFileListCount; ++i)
+			for(size_t i = 0; i < mFileListCount; ++i)
 			{
 				FileInfo& entry = mFileList[i];
 				// delete

--- a/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherOSX.cpp
+++ b/Aurora/RuntimeCompiler/SimpleFileWatcher/FileWatcherOSX.cpp
@@ -338,6 +338,7 @@ namespace FW
 	//--------
 	WatchID FileWatcherOSX::addWatch(const String& directory, FileWatchListener* watcher, bool recursive)
 	{
+		(void) recursive;
 /*		int fd = open(directory.c_str(), O_RDONLY);
 		if(fd == -1)
 			perror("open");
@@ -392,6 +393,9 @@ namespace FW
 	//--------
 	void FileWatcherOSX::handleAction(WatchStruct* watch, const String& filename, unsigned long action)
 	{
+				(void)watch;
+				(void)filename;
+				(void)action;
         assert(false);//should not get here for OSX impl
 	}
 

--- a/Aurora/RuntimeObjectSystem/IObject.h
+++ b/Aurora/RuntimeObjectSystem/IObject.h
@@ -98,6 +98,7 @@ struct IObject
 	// Will automatically be called with isFirstInit=false whenever a system serialization is performed
 	virtual void Init( bool isFirstInit )
 	{
+		(void)isFirstInit;
 	}
 
 	//return the PerTypeObjectId of this object, which is unique per class
@@ -120,7 +121,7 @@ struct IObject
 	virtual IObjectConstructor* GetConstructor() const = 0;
 
 	//serialise is not pure virtual as many objects do not need state
-	virtual void Serialize(ISimpleSerializer *pSerializer) {};
+	virtual void Serialize(ISimpleSerializer *pSerializer) { (void)pSerializer; };
 
 	virtual const char* GetTypeName() const = 0;
 

--- a/Aurora/RuntimeObjectSystem/IRuntimeObjectSystem.h
+++ b/Aurora/RuntimeObjectSystem/IRuntimeObjectSystem.h
@@ -43,6 +43,8 @@ enum TestBuildResult
 
 struct ITestBuildNotifier
 {
+    virtual ~ITestBuildNotifier() = default;
+
     // Notifier gets name of file which and result type.
     // Errors will also be output to log in 'standard' RCC++ way.
     // file may be NULL if type TESTBUILDFAILTYPE_NO_FILES_TO_BUILD.

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
@@ -191,6 +191,7 @@ bool RuntimeObjectSystem::GetIsCompiledComplete()
 
 void RuntimeObjectSystem::CompileAllInProject( bool bForceRecompile, unsigned short projectId_ )
 {
+    (void)bForceRecompile;
     ProjectSettings& project = GetProject( projectId_ );
     // since this is a compile all we can clear any pending compiles
     project.m_BuildFileList.clear( );

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
@@ -159,8 +159,8 @@ void RuntimeObjectSystem::OnFileChange(const IAUDynArray<const char*>& filelist)
                 {
                     if( itrCurr->second == fileToBuild.filePath )
                     {
-                        BuildTool::FileToBuild fileToBuild( itrCurr->first );
-                        pBuildFileList->push_back( fileToBuild );
+                        BuildTool::FileToBuild fileToBuild2( itrCurr->first );
+                        pBuildFileList->push_back( fileToBuild2 );
                     }
                     ++itrCurr;
                 }
@@ -169,9 +169,9 @@ void RuntimeObjectSystem::OnFileChange(const IAUDynArray<const char*>& filelist)
             if( bFindIncludeDependencies )
             {
                 TFileToFilesEqualRange range = m_Projects[ proj ].m_RuntimeIncludeMap.equal_range( fileToBuild.filePath );
-                for( TFileToFilesIterator it = range.first; it != range.second; ++it )
+                for( TFileToFilesIterator it2 = range.first; it2 != range.second; ++it2 )
                 {
-                    BuildTool::FileToBuild fileToBuildFromIncludes( ( *it ).second, bForceIncludeDependencies );
+                    BuildTool::FileToBuild fileToBuildFromIncludes( ( *it2 ).second, bForceIncludeDependencies );
                     pBuildFileList->push_back( fileToBuildFromIncludes );
                 }
             }
@@ -328,14 +328,14 @@ void RuntimeObjectSystem::StartRecompile()
 
 
 	//Add libraries which need linking
-	std::vector<FileSystemUtils::Path> linkLibraryList;
+	std::vector<FileSystemUtils::Path> linkLibraryList2;
 	for( size_t i = 0; i < ourBuildFileList.size(); ++ i )
 	{
 
         TFileToFilesEqualRange range = m_Projects[ project ].m_RuntimeLinkLibraryMap.equal_range( ourBuildFileList[ i ].filePath );
 		for(TFileToFilesIterator it=range.first; it!=range.second; ++it)
 		{
-			linkLibraryList.push_back( it->second );
+			linkLibraryList2.push_back( it->second );
 		}
 	}
 
@@ -370,7 +370,7 @@ void RuntimeObjectSystem::StartRecompile()
 
     m_pBuildTool->BuildModule(  ourBuildFileList,
                                 m_Projects[ project ].m_CompilerOptions,
-								linkLibraryList, m_CurrentlyCompilingModuleName );
+								linkLibraryList2, m_CurrentlyCompilingModuleName );
 }
 
 bool RuntimeObjectSystem::LoadCompiledModule()

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
@@ -894,7 +894,7 @@ static int TestBuildFile( ICompilerLogger* pLog, RuntimeObjectSystem* pRTObjSys,
             else
             {
                 ++numErrors;
-                if( pRTObjSys->GetNumberLoadedModules() == numCurrLoadedModules )
+                if( (int)pRTObjSys->GetNumberLoadedModules() == numCurrLoadedModules )
                 {
                     if( !callback->TestBuildCallback( file.c_str(), TESTBUILDRRESULT_BUILD_FAILED ) ) { return -numErrors; }
                 }

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
@@ -63,10 +63,10 @@ RuntimeObjectSystem::RuntimeObjectSystem()
 	, m_bCompiling( false )
 	, m_bLastLoadModuleSuccess( false )
 	, m_bAutoCompile( true )
+    , m_CurrentlyBuildingProject( 0 )
     , m_TotalLoadedModulesEver(1) // starts at one for current exe
     , m_bProtectionEnabled( true )
     , m_pImpl( 0 )
-    , m_CurrentlyBuildingProject( 0 )
 {
     ProjectSettings::ms_DefaultIntermediatePath = FileSystemUtils::GetCurrentPath() / "Runtime";
     CreatePlatformImpl();

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem_PlatformPosix.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem_PlatformPosix.cpp
@@ -83,6 +83,7 @@ void RuntimeObjectSystem::SetProtectionEnabled( bool bProtectionEnabled_ )
 
 void signalHandler(int sig, siginfo_t *info, void *context)
 {
+    (void) context;
     // we only handle synchronous signals with this handler, so they come to the correct thread.
     assert( m_pCurrProtector );
     

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem_PlatformPosix.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem_PlatformPosix.cpp
@@ -66,7 +66,7 @@ void RuntimeObjectSystem::SetProtectionEnabled( bool bProtectionEnabled_ )
     {
         if( ms_bMachPortSet )
         {
-            for( int i = 0; i < old_count; ++i )
+            for( int i = 0; i < static_cast<int>(old_count); ++i )
             {
                 task_set_exception_ports( mach_task_self(), old_masks[i], old_ports[i], old_behaviors[i], old_flavors[i]);
             }

--- a/Aurora/RuntimeObjectSystem/RuntimeTracking.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeTracking.h
@@ -59,6 +59,7 @@ struct IRuntimeTracking
 	IRuntimeTracking( size_t max ) : MaxNum( max )
 	{
 	}
+	virtual ~IRuntimeTracking() = default;
 
 	// GetIncludeFile may return 0, so you should iterate through to GetMaxNum() ignoring 0 returns
 	virtual RuntimeTackingInfo GetTrackingInfo( size_t Num_ ) const
@@ -92,6 +93,7 @@ template<> struct RuntimeTracking<0> : IRuntimeTracking
 	RuntimeTracking() : IRuntimeTracking( 0 )
 	{
 	}
+	virtual ~RuntimeTracking() = default;
 };
 
 RCCPP_OPTMIZE_ON

--- a/Aurora/RuntimeObjectSystem/RuntimeTracking.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeTracking.h
@@ -34,17 +34,17 @@
 // RemoveAnyFileName( relativeToPath ) + ReplaceExtension( filename, extension  )
 struct SourceDependencyInfo
 {
-	const char* filename;			// If NULL then no SourceDependencyInfo
-	const char* extension;			// If NULL then use extension in filename
-	const char* relativeToPath;		// If NULL filename is either full or relative to known path
+	const char* filename = nullptr;			// If NULL then no SourceDependencyInfo
+	const char* extension = nullptr;			// If NULL then use extension in filename
+	const char* relativeToPath = nullptr;		// If NULL filename is either full or relative to known path
 };
 
 struct RuntimeTackingInfo
 {
-    static RuntimeTackingInfo GetNULL() { RuntimeTackingInfo ret = {0}; return ret; }
+	static RuntimeTackingInfo GetNULL() { RuntimeTackingInfo ret; return ret; }
 	SourceDependencyInfo sourceDependencyInfo;
-	const char*          linkLibrary;
-	const char*          includeFile;
+	const char*          linkLibrary = nullptr;
+	const char*          includeFile = nullptr;
 };
 
 

--- a/Aurora/RuntimeObjectSystem/RuntimeTracking.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeTracking.h
@@ -64,6 +64,7 @@ struct IRuntimeTracking
 	// GetIncludeFile may return 0, so you should iterate through to GetMaxNum() ignoring 0 returns
 	virtual RuntimeTackingInfo GetTrackingInfo( size_t Num_ ) const
 	{
+		(void)Num_;
 		return RuntimeTackingInfo::GetNULL();
 	}
 


### PR DESCRIPTION
Those are simple warning corrections against some classic warnings (-Wmissing-field-initializers,
-Wunused-parameter,  -Wnon-virtual-dtor, -Wreorder, -Wshadow, -Wsign-compare, -Wunused-const-variable)


