### PR TITLE
Fixed clang build on windows platform

### DIFF
--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem_PlatformWindows.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem_PlatformWindows.cpp
@@ -165,11 +165,12 @@ bool RuntimeObjectSystem::TryProtectedFunction( RuntimeProtector* pProtectedObje
 	{
         if( !pProtectedObject_->m_bHashadException )
         {
+		RuntimeObjectSystem* thisCopy = this;
 	        __try
             {
 		        pProtectedObject_->ProtectedFunc();
 	        }
-            __except( m_pImpl->SimpleExceptionFilter( GetExceptionInformation(), pProtectedObject_ ) )
+            __except( thisCopy->m_pImpl->SimpleExceptionFilter( GetExceptionInformation(), pProtectedObject_ ) )
 	        {
 		        // If we hit any structured exception, exceptionInfo will be initialized
 		        // If it's one we recognise and we hinted for no debugging, we'll go straight here, with info filled out


### PR DESCRIPTION
```
D:\repos\RuntimeCompiledCPlusPlus\Aurora\RuntimeObjectSystem\RuntimeObjectSystem_PlatformWindows.cpp(155,27): error : cannot compile this 'this' captured by SEH yet
```
Clang compiler on Windows cannot use `this` pointer inside SEH exception try-catch block. There is a simple warkaround for that - save `this` pointer into a local variable