### PR TITLE
Fixed compilation of same file multiple times due to storing both relative and absolute paths

### DIFF
--- a/Aurora/RuntimeCompiler/FileSystemUtils.h
+++ b/Aurora/RuntimeCompiler/FileSystemUtils.h
@@ -85,6 +85,7 @@ namespace FileSystemUtils
 
 		bool		Exists()			const;
 		bool        IsDirectory()       const;
+		bool        IsRelative()        const;
 		bool		CreateDir()			const;
 		bool		Remove()			const;
 		bool		RemoveDir()         const; // The directory must be empty, and it must not be the current working directory or the root directory.
@@ -322,6 +323,15 @@ namespace FileSystemUtils
 			isDir = 0 != (buffer.st_mode & S_IFDIR);
 		}
 		return isDir;
+	}
+
+	inline bool Path::IsRelative() const
+	{
+		// Not sure if it is a good way to check if a path is relative
+		// I suppose that all files which start from . or .. are considered relative
+		// if . or .. exists in other parts of file path, GetCleanPath() will handle them,
+		// so here we only need to check for the first file symbol (either . or ..)
+		return m_string.find('.') == 0;
 	}
 
 	inline bool Path::CreateDir() const

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.cpp
@@ -477,8 +477,12 @@ void RuntimeObjectSystem::SetupRuntimeFileTracking(const IAUDynArray<IObjectCons
 		{
 			continue;
 		}
+        // make sure that file is absolute. If file path is relative, we assume that it is relative to the
+        // current working directory, otherwise we left it as is (but still clean from unnecessary symbols)
 		Path filePath = pFilename;
+        filePath = filePath.IsRelative() ? FileSystemUtils::GetCurrentPath() / filePath : filePath;
         filePath = filePath.GetCleanPath();
+
         bool bFound = false;
         filePath = FindFile( filePath, &bFound );
         if( !bFound )


### PR DESCRIPTION
I am building RuntimeCompiledCPlusPlus with CMake on Windows. `__FILE__` macro, which is used inside `REGISTERCLASS` macro, produces relative path to the building directory (so if I have `runtime.cpp` in the project root directory, and build files are written to the `out/build/x64-Debug` directory, `__FILE__` macro for `runtime.cpp` will be equal to `..\..\..\runtime.cpp`.

The problems arise when I try to recompile this file at runtime. In that case `__FILE__` is equal to the **absolute** path of `runtime.cpp`: `D:\repos\RuntimeCppTest\runtime.cpp`, so after recompilation the project starts tracking both relative and absolute paths not checking if they are actually referencing the same file.

This leads to the errors after first recompilation. Below you can see output when `runtime.cpp` is recompiled in runtime for the first time:
```
[info]: FileChangeNotifier triggered recompile with changes to:
[info]:     File ..\..\..\runtime.cpp
[info]: Compiling...
[info]: cl /nologo /Z7 /FC /MDd /LDd /Od   /MP /Fo"D:\repos\RuntimeCppTest\out\build\x64-Clang-Debug\Runtime\DEBUG_DEBUG\\" /D WIN32 /EHa /FeC:\Users\Momo\AppData\Local\Temp\72D4.tmp  /I "..\..\..\runtimecompiledcplusplus\aurora\runtimeobjectsystem" /I "..\..\..\runtimecompiledcplusplus\aurora\RuntimeCompiler" /I "D:/repos/RuntimeCppTest/RuntimeCompiledCPlusPlus/Aurora"  "..\..\..\runtime.cpp" "d:\repos\runtimecpptest\out\build\x64-clang-debug\runtime\debug_debug\objectinterfacepermodulesource.obj"
echo [info]:
[info]: **********************************************************************
[info]: ** Visual Studio 2019 Developer Command Prompt v16.7.5
[info]: ** Copyright (c) 2020 Microsoft Corporation
[info]: **********************************************************************
tick
[info]: [vcvarsall.bat] Environment initialized for: 'x86_x64'
[info]:
[info]: runtime.cpp
tick
[info]:    Creating library C:\Users\Momo\AppData\Local\Temp\72D4.lib and object C:\Users\Momo\AppData\Local\Temp\72D4.exp
[info]:
[info]: [RuntimeCompiler] Complete
[info]: [info]:
[info]: Compilation Succeeded
[info]: Serializing out from 1 old constructors...
[info]: Swapping in and creating objects for 1 new constructors...
[info]: Serialising in...
[info]: Auto Constructing Singletons...
[info]: Initialising and testing new serialisation...
[info]: Object swap completed
```
And here you can see the output when `runtime.cpp` is recompiled for the second time (and etc). VS compiler cannot write to `runtime.obj` more than once, as it already participates in build. As a result, it fails to produce a library:
```
[info]: FileChangeNotifier triggered recompile with changes to:
[info]:     File ..\..\..\runtime.cpp
[info]:     File d:\repos\runtimecpptest\runtime.cpp
[info]: Compiling...
[info]: cl /nologo /Z7 /FC /MDd /LDd /Od   /MP /Fo"D:\repos\RuntimeCppTest\out\build\x64-Clang-Debug\Runtime\DEBUG_DEBUG\\" /D WIN32 /EHa /FeC:\Users\Momo\AppData\Local\Temp\92C0.tmp  /I "..\..\..\runtimecompiledcplusplus\aurora\runtimeobjectsystem" /I "..\..\..\runtimecompiledcplusplus\aurora\RuntimeCompiler" /I "D:/repos/RuntimeCppTest/RuntimeCompiledCPlusPlus/Aurora"  "..\..\..\runtime.cpp" "d:\repos\runtimecpptest\runtime.cpp" "d:\repos\runtimecpptest\out\build\x64-clang-debug\runtime\debug_debug\objectinterfacepermodulesource.obj"
echo [info]:
[info]: **********************************************************************
[info]: ** Visual Studio 2019 Developer Command Prompt v16.7.5
[info]: ** Copyright (c) 2020 Microsoft Corporation
**********************************************************************
tick
[info]: [vcvarsall.bat] Environment initialized for: 'x86_x64'
[info]:
[info]: runtime.cpp
[info]: runtime.cpp
[error]: d:\repos\runtimecpptest\runtime.cpp : fatal error C1083: Cannot open compiler generated file: 'D:\repos\RuntimeCppTest\out\build\x64-Clang-Debug\Runtime\DEBUG_DEBUG\runtime.obj': Permission denied
[info]: cl : Command line error D8040 : [info]: error creating or communicating with child process
[info]:
[info]: [RuntimeCompiler] Complete
[info]: [info]:
[error]: Failed to load module C:\Users\Momo\AppData\Local\Temp\92C0.tmp
```
My solution for that is to check if the filepath provided by `__FILE__` is relative. If so, we need to make it absolute by concatenating it with current working directory. With this fix everything seems to work (at least on my machine).