### PR TITLE
fixed clang warning of not supported pragma on Windows

### DIFF
--- a/Aurora/RuntimeObjectSystem/RuntimeTracking.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeTracking.h
@@ -19,7 +19,7 @@
 
 // the templates used for tracking need not be optimized
 // so we create macros to handle this
-#ifdef _WIN32
+#if defined _WIN32 && !defined __clang__
 	#define RCCPP_OPTMIZE_OFF __pragma( optimize( "", off ) )
 	#define RCCPP_OPTMIZE_ON  __pragma( optimize( "", on ) )
 #else


### PR DESCRIPTION
```
D:\repos\MxEngine\submodules\RuntimeCompiledCPlusPlus\Aurora\RuntimeObjectSystem\RuntimeTracking.h(55,1): warning : '#pragma optimize' is not supported [-Wignored-pragma-optimize]
  RCCPP_OPTMIZE_OFF
  ^
  D:\repos\MxEngine\submodules\RuntimeCompiledCPlusPlus\Aurora\RuntimeObjectSystem\RuntimeTracking.h(23,38): note: expanded from macro 'RCCPP_OPTMIZE_OFF'
          #define RCCPP_OPTMIZE_OFF __pragma( optimize( "", off ) )
                                              ^
D:\repos\MxEngine\submodules\RuntimeCompiledCPlusPlus\Aurora\RuntimeObjectSystem\RuntimeTracking.h(102,1): warning : '#pragma optimize' is not supported [-Wignored-pragma-optimize]
  RCCPP_OPTMIZE_ON
  ^
  D:\repos\MxEngine\submodules\RuntimeCompiledCPlusPlus\Aurora\RuntimeObjectSystem\RuntimeTracking.h(24,38): note: expanded from macro 'RCCPP_OPTMIZE_ON'
          #define RCCPP_OPTMIZE_ON  __pragma( optimize( "", on ) )
```
Clang on Windows does not support #pragma optimize and produces annoying warnings for each file compilation, as `RuntimeTracking.h` implicitly included in all registered classes for runtime compilation.
I did not figured out how to check if code is compiled exactly by cl.exe. _MSC_VER is also defined if code is compiled from Visual Studio. Maybe here should be checks for other compilers too