### PR TITLE
added clang compiler support for Windows platform

### DIFF
--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -262,9 +262,22 @@ char* pCharTypeFlags = "";
 #ifdef UNICODE
 	pCharTypeFlags = "/D UNICODE /D _UNICODE ";
 #endif
+	
+#if defined __clang__
+	#ifndef _WIN64
+	std::string arch = " -m32 ";
+	#else
+	std::string arch = " -m64 ";
+	#endif
+	std::string compilerPath = "\"%VCINSTALLDIR%Tools\\Llvm\\bin\\clang-cl\"";
+	compilerPath += arch;
+#else
+	// full path and arch is not required as cl compiler already initialized by Vcvarsall.bat
+	std::string compilerPath = "cl";
+#endif
 
 	// /MP - use multiple processes to compile if possible. Only speeds up compile for multiple files and not link
-	std::string cmdToSend = "cl " + flags + pCharTypeFlags
+	std::string cmdToSend = compilerPath + flags + pCharTypeFlags
 		+ " /MP /Fo\"" + compilerOptions_.intermediatePath.m_string + "\\\\\" "
 		+ "/D WIN32 /EHa /Fe" + moduleName_.m_string;
 	cmdToSend += " " + strIncludeFiles + " " + strFilesToCompile + strLinkLibraries + linkOptions

--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -265,15 +265,15 @@ char* pCharTypeFlags = "";
 	
 #if defined __clang__
 	#ifndef _WIN64
-	std::string arch = " -m32 ";
+	std::string arch = "-m32 ";
 	#else
-	std::string arch = " -m64 ";
+	std::string arch = "-m64 ";
 	#endif
-	std::string compilerPath = "\"%VCINSTALLDIR%Tools\\Llvm\\bin\\clang-cl\"";
+	std::string compilerPath = "\"%VCINSTALLDIR%Tools\\Llvm\\bin\\clang-cl\" ";
 	compilerPath += arch;
 #else
 	// full path and arch is not required as cl compiler already initialized by Vcvarsall.bat
-	std::string compilerPath = "cl";
+	std::string compilerPath = "cl ";
 #endif
 
 	// /MP - use multiple processes to compile if possible. Only speeds up compile for multiple files and not link


### PR DESCRIPTION
clang-cl on windows is [almost fully compatible](https://clang.llvm.org/docs/MSVCCompatibility.html) with msvc cl compiler, but tends to link libraries [much faster](http://blog.llvm.org/2018/01/improving-link-time-on-windows-with.html) (this is the main reason why I am using it), so supporting it is not that hard if we already know Visual Studio installation folder - clang-cl will be located at `%VCInstallDir% Tools\Llvm\clang-cl.exe` and can be launched in the same way as `cl.exe`
I do not know why Microsoft does not provide shortcut for clang-cl executable neither automatically setup target architecture. There is even [question on their forum](https://developercommunity.visualstudio.com/idea/875419/how-to-use-msvc-installed-c-clang-tools-for-window.html) which was created half a year ago and still not resolved