### PR TITLE
fix warning: ISO C++ forbids converting a string constant to 'char*'

### DIFF
--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -635,7 +635,7 @@ void CmdProcess::InitialiseProcess()
 	}
 	*/
 
-	wchar_t* pCommandLine = L"cmd /q /K @PROMPT $";
+	const wchar_t* pCommandLine = L"cmd /q /K @PROMPT $";
 	//CreateProcessW won't accept a const pointer, so copy to an array 
 	wchar_t pCmdLineNonConst[1024];
 	wcscpy_s(pCmdLineNonConst, pCommandLine);

--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -258,9 +258,10 @@ void Compiler::RunCompile(	const std::vector<FileSystemUtils::Path>&	filesToComp
 
 
 
-char* pCharTypeFlags = "";
 #ifdef UNICODE
-	pCharTypeFlags = "/D UNICODE /D _UNICODE ";
+	const char* pCharTypeFlags = "/D UNICODE /D _UNICODE ";
+#else
+	const char* pCharTypeFlags = "";
 #endif
 
 	std::string compilerLocation = compilerOptions_.compilerLocation.m_string;


### PR DESCRIPTION
C++ standard disallows following code: `char* s = "str"` (see https://github.com/asc-community/MxEngine/issues/38#issuecomment-777035829)