### PR TITLE
Use NDEBUG instead of _DEBUG so that debug / release detection is cross platform

### DIFF
--- a/Aurora/RuntimeCompiler/CompileOptions.h
+++ b/Aurora/RuntimeCompiler/CompileOptions.h
@@ -39,7 +39,7 @@ inline RCppOptimizationLevel GetActualOptimizationLevel( RCppOptimizationLevel o
 {
 	if( RCCPPOPTIMIZATIONLEVEL_DEFAULT == optimizationLevel_ )
 	{
-	#ifdef _DEBUG
+	#ifndef NDEBUG
 		optimizationLevel_ = RCCPPOPTIMIZATIONLEVEL_DEBUG;
 	#else
 		optimizationLevel_ = RCCPPOPTIMIZATIONLEVEL_PERF;


### PR DESCRIPTION
Currently, on linux the "default" compilation config will run the release config even in debug, since _DEBUG is MSVC only.
This PR proposes switching to the `NDEBUG` define, which is specified by the C / C++ standards, and thus should be cross platform.

One minor caveat however is that it used to control asserts, and it can be defined or undefined independently of the actual compilation flags.
I don't know of any standard way to avoid this, so maybe a cleaner solution would be to pass a custom flag trough cmake or something like that, which is a little more complex than a one-line modification :P

In practice however, cmake (and most build systems) sets this flag when not in debug, and from my experience projects that have complex logic for handling which asserts to enable / disable opt for their own custom defines anyway, so I think this is acceptable.