### PR TITLE
Add -dumpbase to gcc compile flags, so that intermediate files have no prefix.

### DIFF
--- a/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
@@ -234,6 +234,11 @@ void Compiler::RunCompile( const std::vector<FileSystemUtils::Path>&	filesToComp
         compileString = "cd \"" + compilerOptions_.intermediatePath.m_string + "\"\n" + compileString + " --save-temps ";
 		output = compilerOptions_.intermediatePath / "a.out";
 		bCopyOutput = true;
+#ifndef __clang__
+		// By default, GCC adds a 'a-' (because our output is a.out) prefix to the intermediary files by default, making us not find the .o files later when recompiling.
+		compileString += "-dumpbase '' ";
+#endif
+
 	}
 	
 	


### PR DESCRIPTION
By default, on `gcc` they seem to have the output's name as prefix, in out case, `a-`.
This means the intermediary files end up with the name of the form "a-XXX.o" instead of "XXX.o", which breaks the code checking if a reusable object file exists.
`g++` has a `-dumpbase` which can be used to control this. Setting it to `''` fixes this issue.
`clang++` has no such option, thus the code is only active in `gcc` builds.
I haven't tested if the bug manifests on clang.