### PR TITLE
[feature] The IObjectConstructor interface now also provides a destructor function.

### DIFF
--- a/Aurora/RuntimeObjectSystem/ObjectFactorySystem/ObjectFactorySystem.cpp
+++ b/Aurora/RuntimeObjectSystem/ObjectFactorySystem/ObjectFactorySystem.cpp
@@ -203,7 +203,6 @@ void ObjectFactorySystem::ProtectedObjectSwapper::ProtectedFunc()
 			//TODO: could put a constructor around this.
 			//constructor has been replaced
 			IObjectConstructor* pOldConstructor = m_ConstructorsOld[i];
-			ObjectDestructor pOldDestructor = pOldConstructor->GetDestructor();
 			size_t numObjects = pOldConstructor->GetNumberConstructedObjects();
 			for( size_t j = 0; j < numObjects; ++j )
 			{
@@ -211,7 +210,7 @@ void ObjectFactorySystem::ProtectedObjectSwapper::ProtectedFunc()
 				if( pOldObject )
 				{
 					pOldObject->_isRuntimeDelete = true;
-					pOldDestructor(pOldObject);
+					pOldConstructor->Destroy( pOldObject );
 				}
 			}
 			pOldConstructor->ClearIfAllDeleted();

--- a/Aurora/RuntimeObjectSystem/ObjectInterface.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterface.h
@@ -66,12 +66,12 @@ struct ObjectId
 };
 
 struct RuntimeTackingInfo;
-typedef void(*ObjectDestructor)(IObject*);
 
 struct IObjectConstructor
 {
 	virtual IObject* Construct() = 0;
 	virtual void ConstructNull() = 0;	//for use in object replacement, ensures a deleted object can be replaced
+	virtual void Destroy( IObject* object ) = 0;
 	virtual const char* GetName() = 0;
 	virtual const char* GetFileName() = 0;
 	virtual const char* GetCompiledPath() = 0;
@@ -87,9 +87,6 @@ struct IObjectConstructor
     {
         return Construct();
     }
-
-	// Lifetime management
-	virtual ObjectDestructor GetDestructor() const = 0; // Accessing the destructor paired with the constructor
 
 	virtual IObject* GetConstructedObject( PerTypeObjectId num ) const = 0;	//should return 0 for last or deleted object
 	virtual size_t	 GetNumberConstructedObjects() const = 0;

--- a/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
@@ -227,14 +227,9 @@ public:
         return m_bIsSingleton && m_bIsAutoConstructSingleton;
     }
 
-	static void DefaultObjectDestructor(IObject* object)
+	virtual void Destroy( IObject* object )
 	{
 		delete object;
-	}
-
-	virtual ObjectDestructor GetDestructor() const
-	{
-		return DefaultObjectDestructor;
 	}
 
 	virtual IObject* GetConstructedObject( PerTypeObjectId id ) const


### PR DESCRIPTION
* The default version works just like previously by deleting the object passed to it.
* This gives more control to users when specializing "TObjectConstructorConcrete"

I'll try to keep the code style and visuals as close to what currently is in the repository. Though I guess a facelift would be nice, but fighting styles are worse than a consistent older one.

Part of: #138 