### PR TITLE
[feature] Introducing an IObjectAllocator interface.

### DIFF
--- a/Aurora/CMakeLists.txt
+++ b/Aurora/CMakeLists.txt
@@ -6,7 +6,21 @@ project( RuntimeCompiledCPlusPlus )
 #
 option(BUILD_EXAMPLES "Build example applications" ON)
 option(GLFW_SYSTEM    "Use the operating system glfw library" OFF)
+option(RCCPP_ALLOCATOR_INTERFACE "Builds RCCPP with object allocation done using an allocator interface." OFF)
 
+#
+# Project features
+#
+if(RCCPP_ALLOCATOR_INTERFACE)
+	message(STATUS "Building with allocator interface")
+	add_compile_definitions(RCCPP_ALLOCATOR_INTERFACE=1)
+else()
+	message(STATUS "Building with standard new/delete")
+endif()
+
+#
+# General build setup
+#
 if(UNIX AND NOT APPLE)
 	set(BUILD_TYPE SHARED)
 else()

--- a/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformPosix.cpp
@@ -235,8 +235,12 @@ void Compiler::RunCompile( const std::vector<FileSystemUtils::Path>&	filesToComp
 		output = compilerOptions_.intermediatePath / "a.out";
 		bCopyOutput = true;
 	}
-	
-	
+
+    // defines
+#if RCCPP_ALLOCATOR_INTERFACE
+    compileString += "-DRCCPP_ALLOCATOR_INTERFACE=1 ";
+#endif
+
     // include directories
     for( size_t i = 0; i < includeDirList.size(); ++i )
 	{

--- a/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
+++ b/Aurora/RuntimeCompiler/Compiler_PlatformWindows.cpp
@@ -266,9 +266,10 @@ void Compiler::RunCompile(	const std::vector<FileSystemUtils::Path>&	filesToComp
 	{
 		strLinkLibraries += " \"" + ExpandEnvVars( linkLibraryList_[i].m_string ) + "\" ";
 	}
-	
 
-
+#if RCCPP_ALLOCATOR_INTERFACE
+	flags += " /DRCCPP_ALLOCATOR_INTERFACE=1";
+#endif
 
 #ifdef UNICODE
 	const char* pCharTypeFlags = "/D UNICODE /D _UNICODE ";

--- a/Aurora/RuntimeObjectSystem/IObjectFactorySystem.h
+++ b/Aurora/RuntimeObjectSystem/IObjectFactorySystem.h
@@ -36,6 +36,11 @@ struct IObjectFactoryListener
 
 struct IObjectFactorySystem
 {
+#if RCCPP_ALLOCATOR_INTERFACE
+	virtual IObjectAllocator*	GetAllocator() const = 0;
+	virtual void				SetAllocator( IObjectAllocator* pAllocator ) = 0;
+#endif
+
 	virtual IObjectConstructor* GetConstructor( const char* type ) const = 0;
 	virtual ConstructorId		GetConstructorId( const char* type ) const = 0;
 	virtual IObjectConstructor* GetConstructor( ConstructorId id ) const = 0;

--- a/Aurora/RuntimeObjectSystem/IRuntimeObjectSystem.h
+++ b/Aurora/RuntimeObjectSystem/IRuntimeObjectSystem.h
@@ -69,9 +69,15 @@ namespace FileSystemUtils
 
 struct IRuntimeObjectSystem : public ITestBuildNotifier
 {
-	// Initialise RuntimeObjectSystem. pLogger and pSystemTable should be deleted by creator. 
+#if RCCPP_ALLOCATOR_INTERFACE
+    // Initialise RuntimeObjectSystem. pLogger, pSystemTable and pCustomAllocator should be deleted by creator.
+    // Both pLogger and pSystemTable can be 0
+	virtual bool Initialise( ICompilerLogger * pLogger, SystemTable* pSystemTable, IObjectAllocator* pCustomAllocator = nullptr ) = 0;
+#else
+	// Initialise RuntimeObjectSystem. pLogger and pSystemTable should be deleted by creator.
 	// Both pLogger and pSystemTable can be 0
-	virtual bool Initialise( ICompilerLogger * pLogger, SystemTable* pSystemTable  ) = 0;
+	virtual bool Initialise( ICompilerLogger * pLogger, SystemTable* pSystemTable ) = 0;
+#endif
 
 	virtual bool GetIsCompiling() = 0;
 	virtual bool GetIsCompiledComplete() = 0;

--- a/Aurora/RuntimeObjectSystem/ObjectFactorySystem/ObjectFactorySystem.h
+++ b/Aurora/RuntimeObjectSystem/ObjectFactorySystem/ObjectFactorySystem.h
@@ -27,6 +27,35 @@
 #include <string>
 #include <set>
 
+
+#if RCCPP_ALLOCATOR_INTERFACE
+struct DefaultObjectAllocator : public IObjectAllocator
+{
+#ifdef _WIN32
+	virtual void* Allocate( size_t size, size_t alignment )
+	{
+		return _aligned_malloc( size, alignment );
+	}
+	virtual void Free( void* p )
+	{
+		_aligned_free( p );
+	}
+#else
+	virtual void* Allocate( size_t size, size_t alignment )
+	{
+		void* pRet;
+		int retval = posix_memalign( &pRet, alignment, size );
+		(void)retval;	//unused
+		return pRet;
+	}
+	virtual void Free( void* p )
+	{
+		free( p );
+	}
+#endif
+};
+#endif
+
 // class  ObjectFactorySystem
 // implements interface IObjectFactorySystem
 // also implements RuntimeProtector so that when new constructors are added and used,
@@ -37,11 +66,26 @@ public:
 	ObjectFactorySystem()
 		: m_pLogger( 0 )
 		, m_pRuntimeObjectSystem( 0 )
-        , m_bTestSerialization(true)
+#if RCCPP_ALLOCATOR_INTERFACE
+		, m_DefaultAllocator( )
+		, m_pAllocator( &m_DefaultAllocator )
+#endif
+        , m_bTestSerialization( true )
 		, m_HistoryMaxSize( 0 )
 		, m_HistoryCurrentLocation( 0 )
  	{
 	}
+
+#if RCCPP_ALLOCATOR_INTERFACE
+	virtual IObjectAllocator* GetAllocator() const
+	{
+		return m_pAllocator;
+	}
+	virtual void SetAllocator( IObjectAllocator* pAllocator )
+	{
+		m_pAllocator = pAllocator;
+	}
+#endif
 
 	virtual IObjectConstructor* GetConstructor( const char* type ) const;
 	virtual ConstructorId GetConstructorId( const char* type ) const;
@@ -86,6 +130,10 @@ private:
 	TObjectFactoryListeners 			m_Listeners;
 	ICompilerLogger* 					m_pLogger;
     IRuntimeObjectSystem* 				m_pRuntimeObjectSystem;
+#if RCCPP_ALLOCATOR_INTERFACE
+	DefaultObjectAllocator				m_DefaultAllocator;
+	IObjectAllocator*					m_pAllocator;
+#endif
 	bool                                m_bTestSerialization;
 
 	// History

--- a/Aurora/RuntimeObjectSystem/ObjectInterface.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterface.h
@@ -20,6 +20,10 @@
 #ifndef OBJECTINTERFACE_INCLUDED
 #define OBJECTINTERFACE_INCLUDED
 
+#ifndef RCCPP_ALLOCATOR_INTERFACE
+#define RCCPP_ALLOCATOR_INTERFACE 0
+#endif
+
 #include <vector>
 #include <stdlib.h>
 
@@ -65,10 +69,25 @@ struct ObjectId
 	}
 };
 
+#if RCCPP_ALLOCATOR_INTERFACE
+struct IObjectAllocator
+{
+	virtual ~IObjectAllocator() = default;
+	virtual void* Allocate( size_t size, size_t alignment ) = 0;
+	virtual void Free( void* p ) = 0;
+};
+#endif
+
 struct RuntimeTackingInfo;
 
 struct IObjectConstructor
 {
+#if RCCPP_ALLOCATOR_INTERFACE
+	// Memory management
+	virtual IObjectAllocator* GetAllocator() const = 0;
+	virtual void SetAllocator( IObjectAllocator* pAllocator ) = 0;
+#endif
+
 	virtual IObject* Construct() = 0;
 	virtual void ConstructNull() = 0;	//for use in object replacement, ensures a deleted object can be replaced
 	virtual const char* GetName() = 0;

--- a/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
+++ b/Aurora/RuntimeObjectSystem/ObjectInterfacePerModule.h
@@ -123,6 +123,17 @@ public:
 		m_Id = InvalidId;
 	}
 
+#if RCCPP_ALLOCATOR_INTERFACE
+	IObjectAllocator* GetAllocator() const
+	{
+		return m_pAllocator;
+	}
+	void SetAllocator( IObjectAllocator* pAllocator )
+	{
+		m_pAllocator = pAllocator;
+	}
+#endif
+
 	virtual IObject* Construct()
 	{
 		T* pT = 0;
@@ -274,6 +285,9 @@ public:
 	}
 
 private:
+#if RCCPP_ALLOCATOR_INTERFACE
+	IObjectAllocator* 				m_pAllocator;
+#endif
 	bool                            m_bIsSingleton;
 	bool                            m_bIsAutoConstructSingleton;
 	std::vector<T*>                 m_ConstructedObjects;
@@ -292,6 +306,16 @@ template<typename T> class TActual: public T
 {
 public:
 	// overload new/delete to get alignment correct
+#if RCCPP_ALLOCATOR_INTERFACE
+	void* operator new( size_t size )
+	{
+		return m_Constructor.GetAllocator()->Allocate( size, __alignof( TActual<T> ) );
+	}
+	void operator delete( void* p )
+	{
+		m_Constructor.GetAllocator()->Free( p );
+	}
+#else
 #ifdef _WIN32
 	void* operator new(size_t size)
 	{
@@ -315,7 +339,8 @@ public:
 	{
 		free( p );
 	}
-#endif //_WIN32
+#endif // _WIN32
+#endif // RCCPP_ALLOCATOR_INTERFACE
 	friend class TObjectConstructorConcrete<TActual>;
 	virtual ~TActual() { m_Constructor.DeRegister( m_Id ); }
 	virtual PerTypeObjectId GetPerTypeId() const { return m_Id; }

--- a/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.h
+++ b/Aurora/RuntimeObjectSystem/RuntimeObjectSystem.h
@@ -47,8 +47,13 @@ public:
 	RuntimeObjectSystem();
 	virtual ~RuntimeObjectSystem();
 
+#if RCCPP_ALLOCATOR_INTERFACE
+	// Initialise RuntimeObjectSystem. pLogger should be deleted by creator
+	virtual bool Initialise( ICompilerLogger * pLogger, SystemTable* pSystemTable, IObjectAllocator* pCustomAllocator = nullptr );
+#else
 	// Initialise RuntimeObjectSystem. pLogger should be deleted by creator
 	virtual bool Initialise( ICompilerLogger * pLogger, SystemTable* pSystemTable );
+#endif
 
 	virtual bool GetIsCompiling()
 	{


### PR DESCRIPTION
Introducing an IObjectAllocator interface that can be used to handle allocations for TActual objects.
* The allocator is set for each constructor during constructor registration.
* Default implementation is provided in the ObjectFactorySystem.

This is the second thing I was talking about, I've tested, and the changes will compile and run without issues for both cmake options of this feature.

I will do a second pass on some parts, for example moving the implementation details of "DefaultObjectAllocator" to the .cpp