### PR TITLE
Add options to selectively build example applications (ConsoleExample / SimpleTest) [compilation errors on Arco Linux]

### DIFF
--- a/Aurora/CMakeLists.txt
+++ b/Aurora/CMakeLists.txt
@@ -62,16 +62,20 @@ install(TARGETS RuntimeObjectSystem RuntimeCompiler
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
 
 if(BUILD_EXAMPLES)
+	option(BUILD_EXAMPLE_CONSOLE "Build ConsoleExample" ON)
+	option(BUILD_EXAMPLE_SIMPLETEST "Build SimpleTest" ON)
 
-
+	if(BUILD_EXAMPLE_CONSOLE)
 	#
 	# ConsoleExample
 	#
 
 	add_executable(ConsoleExample ${ConsoleExample_SRCS})
 	target_link_libraries(ConsoleExample RuntimeCompiler RuntimeObjectSystem)
+	endif() # if(BUILD_EXAMPLE_CONSOLE)
 
-	
+	if(BUILD_EXAMPLE_SIMPLETEST)
+
 	find_package(OpenGL)
 	if(OpenGL_FOUND)
 		#
@@ -190,4 +194,5 @@ if(BUILD_EXAMPLES)
 	else()  # OpenGL_FOUND
 		message(WARNING "OpenGL not found, not creating graphical example")
 	endif() # OpenGL_FOUND
-endif()
+	endif() # BUILD_EXAMPLE_SIMPLETEST
+endif() # BUILD_EXAMPLES


### PR DESCRIPTION
## Summary

This pull request introduces two new optional CMake switches:

```cmake
BUILD_EXAMPLE_CONSOLE   # Enables/disables building of ConsoleExample (default: ON)
BUILD_EXAMPLE_SIMPLETEST # Enables/disables building of SimpleTest (default: ON)
```

These options allow building individual examples instead of always compiling all of them when `BUILD_EXAMPLES=ON` is set.

---

## Background / Motivation

While building the project on **Linux (GCC 15.1.1, CMake ≥3.12)**, I encountered a linking error during the `SimpleTest` example build:

```
/usr/bin/ld: External/glfw/libX11/libglfw.a(init.o): relocation R_X86_64_32 against symbol `_glfwLibrary' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/SimpleTest.dir/build.make:755: SimpleTest] Error 1
make[1]: *** [CMakeFiles/Makefile2:297: CMakeFiles/SimpleTest.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

The `ConsoleExample` builds and runs correctly, but `SimpleTest` fails due to static GLFW linkage (`External/glfw/libX11/libglfw.a`) being built without `-fPIC`.

Currently, `BUILD_EXAMPLES` is an all-or-nothing option, so it’s not possible to build only `ConsoleExample` without also trying to link `SimpleTest`.

---

## Changes Introduced

* Added two new CMake options under the existing `if(BUILD_EXAMPLES)` block:

  ```cmake
  option(BUILD_EXAMPLE_CONSOLE "Build ConsoleExample" ON)
  option(BUILD_EXAMPLE_SIMPLETEST "Build SimpleTest" ON)
  ```

* Wrapped the existing example definitions in minimal conditional guards:

  ```cmake
  if(BUILD_EXAMPLE_CONSOLE)
      add_executable(ConsoleExample ...)
  endif()

  if(BUILD_EXAMPLE_SIMPLETEST)
      ... existing SimpleTest setup ...
  endif()
  ```

* No other formatting or structural changes were made.
  (Spacing, comments, and logic are preserved exactly as before.)

---

## Benefits

* Allows users to **skip building the graphical example** (`SimpleTest`) when it fails to link or when OpenGL/glfw are not available.
* Keeps **default behavior unchanged** — if `BUILD_EXAMPLES=ON`, both examples still build by default.
* Reduces unnecessary rebuilds and simplifies CI configuration for headless systems.

---

## Example usage

```bash
# build both examples (default)
cmake .. -DBUILD_EXAMPLES=ON

# build only ConsoleExample
cmake .. -DBUILD_EXAMPLES=ON -DBUILD_EXAMPLE_CONSOLE=ON -DBUILD_EXAMPLE_SIMPLETEST=OFF

# build only SimpleTest
cmake .. -DBUILD_EXAMPLES=ON -DBUILD_EXAMPLE_CONSOLE=OFF -DBUILD_EXAMPLE_SIMPLETEST=ON
```

---

## Notes

This PR intentionally keeps the patch **minimal and non-disruptive** —
only conditional guards were added, and no indentation or unrelated lines were changed.
All existing logic, dependencies, and install targets remain untouched.
_________________________
# Compilation logs
## Before changes:
```
mkdir build && cd build

cmake .. -DBUILD_EXAMPLES=ON
-- The C compiler identification is GNU 15.1.1
-- The CXX compiler identification is GNU 15.1.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building with standard new/delete
-- Found OpenGL: /usr/lib/libOpenGL.so
CMake Error at External/libRocket/Build/CMakeLists.txt:9 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!  
# trying again with -DCMAKE_POLICY_VERSION_MINIMUM=3.5
cmake ../ -DBUILD_EXAMPLES=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 
-- Building with standard new/delete
CMake Deprecation Warning at External/libRocket/Build/CMakeLists.txt:9 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: /home/agh/Pulpit/RuntimeCompiledCPlusPlus/Aurora  

$ make -j8 >/dev/null                                             
/usr/bin/ld: External/glfw/libX11/libglfw.a(init.o): relocation R_X86_64_32 against symbol `_glfwLibrary' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/SimpleTest.dir/build.make:755: SimpleTest] Błąd 1
make[1]: *** [CMakeFiles/Makefile2:297: CMakeFiles/SimpleTest.dir/all] Błąd 2
make[1]: *** Oczekiwanie na niezakończone zadania....
make: *** [Makefile:136: all] Błąd 2   
```
## After changes:
```
cmake . -DBUILD_EXAMPLES=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_EXAMPLE_SIMPLETEST=OFF
-- Building with standard new/delete
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/agh/Pulpit/RCPP_fork/RuntimeCompiledCPlusPlus/Aurora/build                                                                                                                                  
$ make -j8           
[ 47%] Built target RuntimeCompiler
[ 70%] Built target RuntimeObjectSystem
[100%] Built target ConsoleExample  
```
______
AI used to generate description of the PR with corrections and manual testing.